### PR TITLE
Use # instead of table.getn()

### DIFF
--- a/terminal.lua
+++ b/terminal.lua
@@ -427,7 +427,7 @@ function Table(caption, aligns, widths, headers, rows)
 	local top_border = '┌'
 	local row_border = '├'
 	local bottom_border = '└'
-	local last = table.getn(col_width)
+	local last = #col_width
 	local tmpl = ''
 	for i, w in pairs(col_width) do
 		tmpl = tmpl .. string.rep('─', w) .. (i < last and 'm' or '')
@@ -471,7 +471,7 @@ function Table(caption, aligns, widths, headers, rows)
 			
 		end
 		
-		if i < table.getn(rows) then
+		if i < #rows then
 			add(row_border)
 		end
 	end


### PR DESCRIPTION
`table.getn()` was deprecated in Lua 5.1 & removed in 5.2.
As a consequence, trying to use `terminal.lua` on recent versions of Pandoc results in a `PandocLuaException`. (For this to happen, the input file must contain a table)

```
$ pandoc -t ../git/pandoc-terminal-writer/terminal.lua <file>
pandoc: PandocLuaException "../git/pandoc-terminal-writer/terminal.lua:430: attempt to call a nil value (field 'getn')"
```
This commit replaces all occurrences of `table.getn(foo)` with the length operator `#foo`. As far as I can see the interested tables are used as arrays, so the two expressions yield the same result.