### PR TITLE
Improve table width + small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ As Pandoc supports many input formats:
 > (several dialects of) Markdown, reStructuredText, textile, HTML, DocBook,
 > LaTeX, MediaWiki markup, TWiki markup, TikiWiki markup, Creole 1.0, Vimwiki
 > markup, OPML, Emacs Org-Mode, Emacs Muse, txt2tags, Microsoft Word docx,
-> LibreOffice ODT, EPUB, or Haddock markup 
+> LibreOffice ODT, EPUB, or Haddock markup.
 
 this writer is suitable for displaying any document in any of these input
 formats.
@@ -29,7 +29,7 @@ $ pandoc -t [path/to/]terminal.lua [the_document]
 
 # e.g.:
 
-$ pandoc -t terminal.lua README.md 
+$ pandoc -t terminal.lua README.md
 ```
 
 As word wrapping is not yet supported, you may want to pipe the output into the
@@ -43,25 +43,37 @@ Note that currently the word wrapping as implemented by `fold` will break the
 indentation and the code and quote blocks decorations. This is an issue we want
 to address inside the writer in the near future.
 
+This writer tries to adapt automatically the maximal width of some elements (like
+_table_ or _blockquotes_). If you want to narrow those elements, you can export
+the "`COLUMNS`" environment variable with the terminal width of you choice:
+
+```bash
+$ COLUMNS=80 pandoc -t terminal.lua README.md | less -r
+```
+
 ## Demo
 
 A screenshot is worth 1000 words:
 
 This document :
 
-![](res/screenshot1.png)
+![Current README.md](res/screenshot1.png)
 
 Another Markdown document :
 
-![](res/screenshot2.png)
+![the showcase.md test document](res/screenshot2.png)
 
 A LibreOffice text document
 
-![](res/screenshot3.png)
+![LibreOffice and terminal rendered document](res/screenshot3.png)
 
-## Author
+## Authors
 
-Camille Oudot (© 2018 Orange)
+© 2018 — 2020 Orange
+
+Camille Oudot
+
+Benoît Bailleux
 
 ## Licence
 

--- a/terminal.lua
+++ b/terminal.lua
@@ -6,6 +6,7 @@
 -- This module is released under the MIT License (MIT).
 -- Please see LICENCE.txt for details.
 -- Author: Camille Oudot
+-- Author: Benoît Bailleux
 
 -- Table to store footnotes, so they can be appended at the end of the output.
 local notes = {}

--- a/test-documents/showcase.md
+++ b/test-documents/showcase.md
@@ -28,8 +28,8 @@ Link without title: <http://foo.bar>
 
 - foo
 - bar:
-    - baz
-    - qux
+  - baz
+  - qux
 - fizz
 - buzz
 
@@ -44,7 +44,7 @@ Link without title: <http://foo.bar>
 
 ### Citations
 
-> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Sed non risus.
 
 ### Code without syntax highlighting
 
@@ -72,7 +72,6 @@ function CodeBlock(s, attr)
 	return ret .. vt100_sda("  ╰───┴───────────┄", "2")
 end
 ```
-
 
 ### Code with syntax highlighting
 
@@ -109,7 +108,7 @@ between
 
 ---
 
-two texts
+two paragraphs
 
 ## Tables
 
@@ -120,4 +119,3 @@ two texts
 | **baz** |           256 | 456          |      y      |
 | ~~qux~~ |           512 | 789          |      z      |
 | `fizz`  |          1024 | 000          |      t      |
-


### PR DESCRIPTION
- Add constants for styles (titles, italic etc.) definition
- Try to guess the terminal window size or use a default value for
  _table_ width or _blockquotes_
- Improve (hopefuly) the _table_ rendering with (nearly) proportional columns
- Make horizontal rule continuous and as wide as possible
- Remove useless `tprint` function
- Update `README.md`
- Fix some minor formatting glitches in `test-documents/showcase.md` sample